### PR TITLE
Add Slovak language

### DIFF
--- a/LICENSE-sk.md
+++ b/LICENSE-sk.md
@@ -1,4 +1,4 @@
-# DON'T BE A DICK PUBLIC LICENSE
+# VERREJNÁ LICENCIA "NEBUĎ TRT"
 
 > Version 1, December 2009
 

--- a/LICENSE-sk.md
+++ b/LICENSE-sk.md
@@ -5,11 +5,6 @@
 > Copyright (C) 2009 Philip Sturgeon <me@philsturgeon.uk>
 > Preklad ~ Jakub Fiala <jakubfiala@me.com>
 
- 
- Everyone is permitted to copy and distribute verbatim or modified
- copies of this license document, and changing it is allowed as long
- as the name is changed.
-
  Tento dokument je dovolené rozmnožovať a šíriť v identickej, alebo modifikovanej forme, 
  a jeho modifikácie sú povolené pod názvom odlišným od pôvodného dokumentu.
 

--- a/LICENSE-sk.md
+++ b/LICENSE-sk.md
@@ -3,7 +3,7 @@
 > Version 1, December 2009
 
 > Copyright (C) 2009 Philip Sturgeon <me@philsturgeon.uk>
-> Preklad ~ Jakub Fiala <jakubfiala@me.com>
+> Preklad ~ Jakub Fiala [fiala.uk](http://fiala.uk)
 
  Tento dokument je dovolené rozmnožovať a šíriť v identickej, alebo modifikovanej forme, 
  a jeho modifikácie sú povolené pod názvom odlišným od pôvodného dokumentu.

--- a/LICENSE-sk.md
+++ b/LICENSE-sk.md
@@ -1,0 +1,31 @@
+# DON'T BE A DICK PUBLIC LICENSE
+
+> Version 1, December 2009
+
+> Copyright (C) 2009 Philip Sturgeon <me@philsturgeon.uk>
+> Preklad ~ Jakub Fiala <jakubfiala@me.com>
+
+ 
+ Everyone is permitted to copy and distribute verbatim or modified
+ copies of this license document, and changing it is allowed as long
+ as the name is changed.
+
+ Tento dokument je dovolené rozmnožovať a šíriť v identickej, alebo modifikovanej forme, 
+ a jeho modifikácie sú povolené pod názvom odlišným od pôvodného dokumentu.
+
+> VEREJNÁ LICENCIA "NEBUĎ TRT"
+> PODMIENKY ROZMNOŽOVANIA, ŠÍRENIA A MODIFIKÁCIE
+
+ 1. Urobte, čo chcete s pôvodným materiálom, len nebuďte trti.
+
+     Byť trtom zahŕňa - okrem iného - nasledovné:
+
+         1a. Porušenie autorských práv - Nezmeňte jednoducho názov a neskopírujte to.
+         1b. Predaj nepozmeneného originálu bez akýchkoľvek zmien, to robia NAOZAJ iba trti.
+         1c. Pridanie škodlivého obsahu do pôvodného materiálu. To by ste boli KRÁĽOVSKÍ trti.
+
+ 2. Ak zbohatnete vďaka modifikáciám, odvodeným dielam/nástrojom, alebo podpore pôvodného materiálu, podeľte sa.
+ Iba trt zarobí kopu peňazí z tohto materiálu a nekúpi tvorcovi/tvorcom pôvodného materiálu pivo.
+ 
+ 3. Zdrojový kód je poskytovaný bez záruky. Iba TOTÁLNY trt používa niekoho zdrojový kód a sťažuje sa keď nefunguje.
+ Opravte to sami. Ne-trt pošle opravený zdrojový kód pôvodným tvorcom.

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ For those of you who want something in between, try the [DBAD license].
 * [Italian] - [StickGrinder](https://twitter.com/StickGrinder)
 * [Romanian] - [Adrian Voicu](https://github.com/avenirer/)
 * [Russian] - [Stanislav Tamat](https://github.com/YokiToki)
+* [Slovak] - [jakubfiala](http://github.com/jakubfiala)
 * [Spanish] - Jano Garcia
 * [Swedish] - [Joseph Landberg](https://github.com/golonka)
 * [Portuguese Brazilian] - [Yarkhan](https://github.com/Yarkhan)

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ For those of you who want something in between, try the [DBAD license].
 [Portuguese Portugal]: https://github.com/philsturgeon/dbad/blob/master/LICENSE-pt-pt.md
 [Romanian]: https://github.com/philsturgeon/dbad/blob/master/LICENCE-ro.md
 [Russian]: https://github.com/philsturgeon/dbad/blob/master/LICENSE-ru.md
+[Slovak]: https://github.com/philsturgeon/dbad/blob/master/LICENSE-sk.md
 [Spanish]: https://github.com/philsturgeon/dbad/blob/master/LICENSE-es.md
 [Swedish]: https://github.com/philsturgeon/dbad/blob/master/LICENSE-sv.md
 [Ukrainian]: https://github.com/philsturgeon/dbad/blob/master/LICENSE-ua.md


### PR DESCRIPTION
This PR adds Slovak language, under which `dick` (not in the literal sense) translates beautifully and rather elegantly as `trt`.