### PR TITLE
Better Czech, typography errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ For those of you who want something in between, try the [DBAD license].
 * [Bulgarian] - Ivan Yonov
 * [Chinese] - [Limi Quens](https://github.com/LimiQS) and [Jiang Chen](https://github.com/JC6)
 * [Traditional Chinese (Taiwan)] - [Yami Odymel](https://github.com/YamiOdymel)
-* [Czech] - [Martin Kolář](https://github.com/mrmartin)
+* [Czech] - [Martin Kolář](https://github.com/mrmartin), Alice Vixie
 * [Dutch] - John Schop
 * [Farsi/Persian] - [Majid Sadeghi G.](https://github.com/dijam)
 * [Finnish] - [39Bit](https://github.com/39bit)

--- a/translations/LICENSE-cz.md
+++ b/translations/LICENSE-cz.md
@@ -1,26 +1,32 @@
 # VEŘEJNÁ LICENCE NEBUĎ KOKOT
 
-> Verze 1.1, Prosinec 2016
+> Verze 1.1, Prosinec 2016  
+> Český překlad ver. 2: 2019-11-28 Martin Kolář <mrmartin.net>, Alice Vixie
 
-> Copyright (C) Philip Sturgeon <email@philsturgeon.co.uk>
-> Překlad Martin Kolář <mrmartin.net>
+> Copyright (C) _rok_ _plné_jméno_
  
- Každý smí kopírovat a distribuovat nezměněné nebo upravené
+ Každý smí kopírovat a distribuovat doslovné nebo upravené
  kopie tohoto licenčního dokumentu.
 
-> VEŘEJNÁ LICENCE NEBUĎ KOKOT
+> VEŘEJNÁ LICENCE NEBUĎ KOKOT  
 > PODMÍNKY PRO KOPÍROVÁNÍ, DISTRIBUCI A MODIFIKACI
 
- 1. Dělej cokoliv co se ti líbí s originálním dílem, jen nebuď kokot.
+1. Dělej s originálním dílem, co uznáš za vhodné, jen nebuď kokot.
 
-     Být kokot zahrnuje - ale není omezeno na - následující případy:
+	Být kokot zahrnuje - ale není omezeno na - následující případy:
 
-	 1a. Pokrytecké překračování autorských práv - Nezkopírujte dílo pod změněným názvem.
-	 1b. Prodávání nemodifikovaného originálu bez jakékoliv práce, to dělá jen SKUTEČNEJ kokot.
-	 1c. Úprava původního díla aby obsahovalo skrytý škodlivý obsah. To bys byl DĚSNĚJ kokot.
+	1a. Nepokryté překračování autorských práv - Nezkopíruj
+		pouze dílo pod změněným názvem.  
+	1b. Prodávání nemodifikovaného originálu bez jakékoliv práce,
+		to dělá jen SKUTEČNÝ kokot.  
+	1c. Úprava původního díla tak, aby obsahovalo skrytý škodlivý obsah.
+		To bys byl OPRAVDU kokot.  
 
- 2. Pokud se zbohatneš prostřednictvím úprav, souvisejících děl/služeb, nebo z poskytování podpory k původnímu dílu,
- sdílej lásku. Pouze kokot by vytěžil z této práce a nekoupil původnímu tvůrci (tvůrkyni, tvůrcům) pivko.
- 
- 3. Kód je poskytován bez záruk. Použití kódu jiného člověka a stežovat si, když nastanou problémy dělá jen OSLÍ kokot.
- Opravte problém sami. Slušnej ne-kokot opravu sdílí nebo předloží zprávu o chybě.
+2. Pokud zbohatneš prostřednictvím úprav, souvisejících děl/služeb
+	nebo poskytováním podpory k původnímu dílu, sdílej lásku.
+	Pouze kokot by těžil z cizí práce, aniž by koupil původním tvůrcům pivko.
+
+3. Kód je poskytován bez záruk. Použít kód jiného člověka a pak si stežovat,
+	když to nefunguje, to dělá jen kokot - OSEL.
+	Ne-kokot problém opraví sám a opravu pošle autorovi, nebo aspoň pošle
+	[zprávu o chybě](http://www.example.com/).


### PR DESCRIPTION
First and foremost motivation was missing two spaces at the end of 1a. 1b. 1c. to create paragraphs, but as I proceeded to read, it just irritated me more and more.

Also replacing  lines 5-6 is a product of comparison with the original where I assume the name of a person granting license should be filled, not the name of the author of the license. Leaving out the line 4 is something that is also to be considered.

Line 18: _nepokryté_ vs _pokrytecké_  - that is _outright_ (new) vs _two-faced_ (old). Plain wrong.

Is the word order sometimes just ... like from Yoda Master.

Keeping lines 80 chars max is something that only a user of text-mode console can understand.