### PR TITLE
add a 4th sentence, and improve readme.md for forks

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,11 +1,12 @@
 # DON'T BE A DICK PUBLIC LICENSE
 
+[Source](https://github.com/philsturgeon/dbad)
+
 > Version 1.1, December 2016
 
 > Copyright (C) [year] [fullname]
  
- Everyone is permitted to copy and distribute verbatim or modified
- copies of this license document.
+ Everyone is permitted to copy and distribute verbatim or modified copies of this license document.
 
 > DON'T BE A DICK PUBLIC LICENSE
 > TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
@@ -23,4 +24,6 @@
  creator(s) a pint.
  
  3. Code is provided with no warranty. Using somebody else's code and bitching when it goes wrong makes 
- you a DONKEY dick. Fix the problem yourself. A non-dick would submit the fix back or submit a [bug report](https://www.chiark.greenend.org.uk/~sgtatham/bugs.html)
+ you a DONKEY dick. Fix the problem yourself. A non-dick would submit the fix back or submit a [bug report](https://www.chiark.greenend.org.uk/~sgtatham/bugs.html).
+
+4. If you use code, only the biggest dick ever would call it their own. Even just a comment saying "SOURCE: example.com" would be OK. A non-dick would submit the fix back or submit a [bug report](https://www.chiark.greenend.org.uk/~sgtatham/bugs.html)

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -26,4 +26,4 @@
  3. Code is provided with no warranty. Using somebody else's code and bitching when it goes wrong makes 
  you a DONKEY dick. Fix the problem yourself. A non-dick would submit the fix back or submit a [bug report](https://www.chiark.greenend.org.uk/~sgtatham/bugs.html).
 
-4. If you use code, calling it your own would make you a ROYAL dick. [How to cite a repo](https://academia.stackexchange.com/questions/14010/how-do-you-cite-a-github-repository)
+4. If you use code, calling it your own would make you a ROYAL dick. [How to cite a repo](https://academia.stackexchange.com/questions/14010/how-do-you-cite-a-github-repository). Alternatively, even just a comment giving attribution to where you found the code would be OK.

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -26,4 +26,4 @@
  3. Code is provided with no warranty. Using somebody else's code and bitching when it goes wrong makes 
  you a DONKEY dick. Fix the problem yourself. A non-dick would submit the fix back or submit a [bug report](https://www.chiark.greenend.org.uk/~sgtatham/bugs.html).
 
-4. If you use code, only the biggest dick ever would call it their own. Even just a comment saying "SOURCE: example.com" would be OK. A non-dick would submit the fix back or submit a [bug report](https://www.chiark.greenend.org.uk/~sgtatham/bugs.html)
+4. If you use code, calling it your own would make you a ROYAL dick. [How to cite a repo](https://academia.stackexchange.com/questions/14010/how-do-you-cite-a-github-repository)

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ For those of you who want something in between, try the [DBAD license].
 * [Greek] - [Thanos Korakas](https://github.com/tkorakas)
 
 
-[DBAD license]: https://github.com/philsturgeon/dbad/blob/master/LICENSE.md
+[DBAD license]: LICENSE.md
 [WTFPL]: http://www.wtfpl.net
 
 [Arabic]: https://github.com/philsturgeon/dbad/blob/master/translations/LICENSE-ar.md


### PR DESCRIPTION
that makes it so that you should add attribution

FYI, this was *partially* inspired by [this PR](https://github.com/philsturgeon/dbad/pull/75) but doesn't limit to academia

one more improvement that this includes — the link to LICENSE.md points correctly to the file no matter whether theres a fork or not!